### PR TITLE
Testing 'NavigationService', fix bugs and add queries for navigation messages

### DIFF
--- a/src/StudentToolkit/Configuration/DI/RegisterServicesExtention.cs
+++ b/src/StudentToolkit/Configuration/DI/RegisterServicesExtention.cs
@@ -1,10 +1,14 @@
-﻿namespace StudentToolkit.Configuration.DI;
+﻿using System;
+
+namespace StudentToolkit.Configuration.DI;
 public static class RegisterServicesExtention
 {
     public static Container RegisterServices(this Container container)
     {
         container.RegisterSingleton<NavigationService>();
         container.RegisterSingleton<DataTemplateService>();
+
+        container.Register<Func<Type, object>>(() => container.GetInstance);
 
         return container;
     }

--- a/src/StudentToolkit/MVVM/Models/Navigation/Messages/ControlContentNavigationMessage.cs
+++ b/src/StudentToolkit/MVVM/Models/Navigation/Messages/ControlContentNavigationMessage.cs
@@ -1,7 +1,0 @@
-﻿namespace StudentToolkit.MVVM.Models.Navigation.Messages;
-
-internal class ControlContentNavigationMessage : ValueChangedMessage<NavigationModel>
-{
-    public ControlContentNavigationMessage(NavigationModel value) 
-        : base(value) { }
-}

--- a/src/StudentToolkit/MVVM/Models/Navigation/Messages/Queries/NavigationQuery.cs
+++ b/src/StudentToolkit/MVVM/Models/Navigation/Messages/Queries/NavigationQuery.cs
@@ -1,0 +1,7 @@
+﻿namespace StudentToolkit.MVVM.Models.Navigation.Messages.Queries;
+
+public abstract class NavigationQuery<T>
+    where T : ValueChangedMessage<NavigationModel>
+{
+    public abstract T Execute(ViewModel viewModel);
+}

--- a/src/StudentToolkit/MVVM/Models/Navigation/Messages/Queries/WindowNavigationQuery.cs
+++ b/src/StudentToolkit/MVVM/Models/Navigation/Messages/Queries/WindowNavigationQuery.cs
@@ -1,0 +1,13 @@
+﻿using StudentToolkit.MVVM.ViewModels.Base;
+
+namespace StudentToolkit.MVVM.Models.Navigation.Messages.Queries;
+
+public sealed class WindowNavigationQuery : NavigationQuery<WindowContentNavigationMessage>
+{
+    public override WindowContentNavigationMessage Execute(ViewModel viewModel)
+    {
+        return
+            new WindowContentNavigationMessage(
+                new NavigationModel(viewModel));
+    }
+}

--- a/src/StudentToolkit/MVVM/Models/Navigation/Messages/WindowContentNavigationMessage.cs
+++ b/src/StudentToolkit/MVVM/Models/Navigation/Messages/WindowContentNavigationMessage.cs
@@ -1,6 +1,6 @@
 ﻿namespace StudentToolkit.MVVM.Models.Navigation.Messages;
 
-internal sealed class WindowContentNavigationMessage : ValueChangedMessage<NavigationModel>
+public sealed class WindowContentNavigationMessage : ValueChangedMessage<NavigationModel>
 {
     public WindowContentNavigationMessage(NavigationModel value) 
         : base(value) { }

--- a/src/StudentToolkit/MVVM/Models/Navigation/NavigationModel.cs
+++ b/src/StudentToolkit/MVVM/Models/Navigation/NavigationModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace StudentToolkit.MVVM.Models.Navigation;
 
-internal sealed class NavigationModel
+public sealed class NavigationModel
 {
     public NavigationModel(ViewModel viewModel)
     {

--- a/src/StudentToolkit/MVVM/ViewModels/Base/INavigatingViewModel.cs
+++ b/src/StudentToolkit/MVVM/ViewModels/Base/INavigatingViewModel.cs
@@ -1,0 +1,3 @@
+﻿namespace StudentToolkit.MVVM.ViewModels.Base;
+
+public interface INavigatingViewModel { }

--- a/src/StudentToolkit/MVVM/ViewModels/Base/ViewModel.cs
+++ b/src/StudentToolkit/MVVM/ViewModels/Base/ViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
-namespace StudentToolkit.MVVM.ViewModels;
+namespace StudentToolkit.MVVM.ViewModels.Base;
 
 public class ViewModel : INotifyPropertyChanged
 {

--- a/src/StudentToolkit/MVVM/ViewModels/MainViewModel.cs
+++ b/src/StudentToolkit/MVVM/ViewModels/MainViewModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace StudentToolkit.MVVM.ViewModels;
 
-public class MainViewModel : ViewModel
+public class MainViewModel : ViewModel, INavigatingViewModel
 {
 
 }

--- a/src/StudentToolkit/Properties/GlobalUsings.cs
+++ b/src/StudentToolkit/Properties/GlobalUsings.cs
@@ -1,13 +1,14 @@
-﻿global using SimpleInjector;
-
-global using CommunityToolkit.Mvvm.Messaging;
+﻿global using CommunityToolkit.Mvvm.Messaging;
 global using CommunityToolkit.Mvvm.Messaging.Messages;
 
-global using StudentToolkit.MVVM.ViewModels;
+global using SimpleInjector;
+
 global using StudentToolkit.Configuration.DI;
 global using StudentToolkit.MVVM.Models.Navigation;
 global using StudentToolkit.MVVM.Models.Navigation.Messages;
-global using StudentToolkit.MVVM.Views;
+global using StudentToolkit.MVVM.Models.Navigation.Messages.Queries;
+global using StudentToolkit.MVVM.ViewModels;
+global using StudentToolkit.MVVM.ViewModels.Base;
 global using StudentToolkit.MVVM.Views.Windows;
-global using StudentToolkit.WpfCore.Commands;
+global using StudentToolkit.WpfCore.Exceptions.Navigation;
 global using StudentToolkit.WpfCore.Services;

--- a/src/StudentToolkit/WpfCore/Exceptions/Navigation/NavigationDeniedException.cs
+++ b/src/StudentToolkit/WpfCore/Exceptions/Navigation/NavigationDeniedException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace StudentToolkit.WpfCore.Exceptions.Navigation;
+
+public class NavigationDeniedException : Exception
+{
+    public NavigationDeniedException(string message)
+        : base(message) { }
+}

--- a/src/StudentToolkit/WpfCore/Services/NavigationService.cs
+++ b/src/StudentToolkit/WpfCore/Services/NavigationService.cs
@@ -2,46 +2,32 @@
 
 namespace StudentToolkit.WpfCore.Services;
 
-internal class NavigationService
+public class NavigationService
 {
-    private readonly Container _container;
+    private readonly Func<Type, object> _viewModelResolver;
 
-    public NavigationService(Container container)
+    public NavigationService(Func<Type, object> viewModelResolver)
     {
-        ArgumentNullException.ThrowIfNull(container, nameof(container));
-
-        _container = container;
+        _viewModelResolver = viewModelResolver;
     }
 
     /// <summary>
-    /// Do navigation to specified view.
+    /// Do navigation to specified view by her view model.
     /// </summary>
-    /// <typeparam name="TViewModel">The view model of specified view.</typeparam>
-    public void NavigateToWindowView<TViewModel>()
+    /// <typeparam name="TViewModel">The navigating view model type.</typeparam>
+    /// <typeparam name="TMessage">The navigation message type.</typeparam>
+    /// <param name="navigationQuery">Query for generating navigation message.</param>
+    /// <exception cref="NavigationDeniedException"></exception>
+    public void NavigateTo<TViewModel, TMessage>(NavigationQuery<TMessage> navigationQuery)
         where TViewModel : ViewModel
+        where TMessage : ValueChangedMessage<NavigationModel>
     {
-        NavigateTo<TViewModel>(typeof(WindowContentNavigationMessage));
-    }
+        var viewModel = (TViewModel)_viewModelResolver(typeof(TViewModel));
 
-    /// <summary>
-    /// Do navigation inside UI control to specified view.
-    /// </summary>
-    /// <typeparam name="TViewModel">The view model of specified view.</typeparam>
-    public void NavigateToControlView<TViewModel>()
-        where TViewModel : ViewModel
-    {
-        NavigateTo<TViewModel>(typeof(ControlContentNavigationMessage));
-    }
+        if (viewModel is not INavigatingViewModel)
+            throw new NavigationDeniedException($"Navigation view model '{typeof(TViewModel).Name}' cannot be use for navigation!");
 
-    private void NavigateTo<TViewModel>(Type messageType)
-        where TViewModel : ViewModel
-    {
-        ViewModel viewModel = _container.GetInstance<TViewModel>();
-
-        var model = new NavigationModel(viewModel);
-
-        var message = Activator.CreateInstance(messageType, model) ??
-            throw new ArgumentException($"Cannot create instance the message of type '{messageType.Name}'!");
+        var message = navigationQuery.Execute(viewModel);
 
         WeakReferenceMessenger.Default.Send(message);
     }

--- a/tests/StudentToolkit.Tests/GlobalUsings.cs
+++ b/tests/StudentToolkit.Tests/GlobalUsings.cs
@@ -1,1 +1,14 @@
+global using CommunityToolkit.Mvvm.Messaging.Messages;
+
+global using StudentToolkit.MVVM.Models.Navigation;
+global using StudentToolkit.MVVM.Models.Navigation.Messages;
+global using StudentToolkit.MVVM.Models.Navigation.Messages.Queries;
+global using StudentToolkit.MVVM.ViewModels;
+global using StudentToolkit.MVVM.ViewModels.Base;
+global using StudentToolkit.Tests.Stubs.Messages;
+global using StudentToolkit.Tests.Stubs.Messages.Queris;
+global using StudentToolkit.Tests.Stubs.ViewModels;
+global using StudentToolkit.WpfCore.Exceptions.Navigation;
+global using StudentToolkit.WpfCore.Services;
+
 global using Xunit;

--- a/tests/StudentToolkit.Tests/Stubs/Messages/Queris/StubNavigationQuery.cs
+++ b/tests/StudentToolkit.Tests/Stubs/Messages/Queris/StubNavigationQuery.cs
@@ -1,0 +1,11 @@
+﻿namespace StudentToolkit.Tests.Stubs.Messages.Queris;
+
+public sealed class StubNavigationQuery : NavigationQuery<StubNavigationMessage>
+{
+    public override StubNavigationMessage Execute(ViewModel viewModel)
+    {
+        return
+            new StubNavigationMessage(
+                new NavigationModel(viewModel));
+    }
+}

--- a/tests/StudentToolkit.Tests/Stubs/Messages/StubNavigationMessage.cs
+++ b/tests/StudentToolkit.Tests/Stubs/Messages/StubNavigationMessage.cs
@@ -1,0 +1,7 @@
+﻿namespace StudentToolkit.Tests.Stubs.Messages;
+
+public sealed class StubNavigationMessage : ValueChangedMessage<NavigationModel>
+{
+    public StubNavigationMessage(NavigationModel value) 
+        : base(value) { }
+}

--- a/tests/StudentToolkit.Tests/Stubs/ViewModels/StubNavigatingViewModel.cs
+++ b/tests/StudentToolkit.Tests/Stubs/ViewModels/StubNavigatingViewModel.cs
@@ -1,0 +1,6 @@
+﻿namespace StudentToolkit.Tests.Stubs.ViewModels;
+
+/// <summary>
+/// Stub view model for testing navigation.
+/// </summary>
+public class StubNavigatingViewModel : ViewModel, INavigatingViewModel { }

--- a/tests/StudentToolkit.Tests/Stubs/ViewModels/StubNotNavigatingViewModel.cs
+++ b/tests/StudentToolkit.Tests/Stubs/ViewModels/StubNotNavigatingViewModel.cs
@@ -1,0 +1,3 @@
+﻿namespace StudentToolkit.Tests.Stubs.ViewModels;
+
+public class StubNotNavigatingViewModel : ViewModel { }

--- a/tests/StudentToolkit.Tests/StudentToolkit.Tests.csproj
+++ b/tests/StudentToolkit.Tests/StudentToolkit.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0-windows</TargetFramework>

--- a/tests/StudentToolkit.Tests/Unit/NavigationServiceTests.cs
+++ b/tests/StudentToolkit.Tests/Unit/NavigationServiceTests.cs
@@ -1,0 +1,69 @@
+﻿namespace StudentToolkit.Tests.Unit;
+
+public class NavigationServiceTests
+{
+    private readonly Dictionary<Type, ViewModel> _viewModels;
+    private readonly Func<Type, object> _viewModelResolver;
+
+    public NavigationServiceTests()
+    {
+        _viewModels = new Dictionary<Type, ViewModel>();
+        _viewModelResolver = (type) => _viewModels[type];
+
+        InitialViewModels();
+    }
+
+    [Fact]
+    public void Should_success_navigation()
+    {
+        // Arrange
+        NavigationService navigationService = new(_viewModelResolver);
+        NavigationViewModel navigationViewModel = (NavigationViewModel)_viewModelResolver(typeof(NavigationViewModel));
+
+        // Act
+        navigationService.NavigateTo<StubNavigatingViewModel, WindowContentNavigationMessage>(new WindowNavigationQuery());
+
+        //Accept
+        Assert.NotNull(navigationViewModel.CurrentViewModel);
+        Assert.IsNotType<MainViewModel>(navigationViewModel.CurrentViewModel);
+        Assert.IsType<StubNavigatingViewModel>(navigationViewModel.CurrentViewModel);
+    }
+
+    [Fact]
+    public void Should_throw_navigation_denied_exception_by_window_navigate()
+    {
+        // Arrange
+        NavigationService navigationService = new(_viewModelResolver);
+        NavigationViewModel navigationViewModel = (NavigationViewModel)_viewModelResolver(typeof(NavigationViewModel));
+
+        // Act
+        void act() => navigationService.NavigateTo<StubNotNavigatingViewModel, WindowContentNavigationMessage>(new WindowNavigationQuery());
+
+        //Accept
+        Assert.Throws<NavigationDeniedException>(act);
+    }
+
+    [Fact]
+    public void Should_does_not_throw_navigation_denied_exception_and_does_not_navigating()
+    {
+        // Arrange
+        NavigationService navigationService = new(_viewModelResolver);
+        NavigationViewModel navigationViewModel = (NavigationViewModel)_viewModelResolver(typeof(NavigationViewModel));
+
+        // Act
+        navigationService.NavigateTo<StubNavigatingViewModel, StubNavigationMessage>(new StubNavigationQuery());
+
+        //Accept
+        Assert.NotNull(navigationViewModel.CurrentViewModel);
+        Assert.IsType<MainViewModel>(navigationViewModel.CurrentViewModel);
+        Assert.IsNotType<StubNavigatingViewModel>(navigationViewModel.CurrentViewModel);
+    }
+
+    private void InitialViewModels()
+    {
+        _viewModels.Add(typeof(MainViewModel), new MainViewModel());
+        _viewModels.Add(typeof(StubNavigatingViewModel), new StubNavigatingViewModel());
+        _viewModels.Add(typeof(StubNotNavigatingViewModel), new StubNotNavigatingViewModel());
+        _viewModels.Add(typeof(NavigationViewModel), new NavigationViewModel(new MainViewModel()));
+    }
+}


### PR DESCRIPTION
## Added:
- Tests for 'NavigationService';
- Stub view models and other objects for testing navigation service;
- Fix founded bugs and architecture errors in navigation model;
- Queries for generating navigation messages;
- 'INavigatingViewModel' as marker of all navigating view models;
- 'NavigatiomDeniedException' if view model not implemented the INavigationViewModel interface;

## Changes:
- Replacement DI container dependency in 'NavigationService' to 'Func<Type, object>' delegate for resolving view models from DI by type;
- Configure 'GlobalUsings' files.

## Deleted:
- 'ControlContentNavigationMessage', because this class maybe not using in future;
- 'NavigateToControlView' method in 'NavigationService'.