### PR TITLE
Refactoring/STL-36 Fix create a new group model instance after every store loading.

### DIFF
--- a/src/StudentToolkit/MVVM/Models/GroupModel.cs
+++ b/src/StudentToolkit/MVVM/Models/GroupModel.cs
@@ -1,4 +1,6 @@
-﻿namespace StudentToolkit.MVVM.Models;
+﻿using StudentToolkit.Domain.Dto;
+
+namespace StudentToolkit.MVVM.Models;
 
 public class GroupModel
 {
@@ -7,4 +9,12 @@ public class GroupModel
     public string GroupCode { get; set; } = string.Empty;
 
     public IEnumerable<StudentModel> Students { get; set; } = [];
+
+    public void Update(GroupDto groupDto)
+    {
+        Students = groupDto.Students.Adapt<IEnumerable<StudentModel>>();
+
+        Id = groupDto.Id;
+        GroupCode = groupDto.GroupCode;
+    }
 }

--- a/src/StudentToolkit/MVVM/Stores/GroupStore.cs
+++ b/src/StudentToolkit/MVVM/Stores/GroupStore.cs
@@ -14,7 +14,7 @@ public sealed class GroupStore : IDisposable
     private readonly WindowsRegistryProvider _registryProvider;
     private readonly Lazy<Task> _lazyInitialization;
 
-    private GroupModel _group;
+    private readonly GroupModel _group;
 
     public GroupStore(
         IGroupService groupService,
@@ -87,14 +87,8 @@ public sealed class GroupStore : IDisposable
             var groupCode = _registryProvider.ReadValue<string>(GroupCodeValueName);
 
             var groupDto = await _groupService.GetGroupAsync(g => g.GroupCode.Equals(groupCode));
-                
-            var students = groupDto.Students.Adapt<ICollection<StudentModel>>();
 
-            _group = new GroupModel()
-            {
-                GroupCode = groupCode,
-                Students = new ObservableCollection<StudentModel>(students)
-            };
+            _group.Update(groupDto);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
After every loading of GroupStore has been creating a new GroupModel instance. Now this instance marked as readonly and cannot be create.