### PR TITLE
Refactoring/STL-63 Fix Sidebar namespace.

### DIFF
--- a/src/StudentToolkit/MVVM/Views/MainView.xaml
+++ b/src/StudentToolkit/MVVM/Views/MainView.xaml
@@ -6,7 +6,7 @@
              xmlns:Behaviors="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:ViewModel="clr-namespace:StudentToolkit.MVVM.ViewModels"
              xmlns:Controls="clr-namespace:StudentToolkit.MVVM.Views.Controls"
-             xmlns:CustomControls="clr-namespace:StudentToolkit.WpfCore.CustomControls.Controls"
+             xmlns:CustomControls="clr-namespace:StudentToolkit.WpfCore.CustomControls"
              mc:Ignorable="d"
              SnapsToDevicePixels="True"
              d:DataContext="{d:DesignInstance Type=ViewModel:MainViewModel}">

--- a/src/StudentToolkit/Resources/Design/Styles/SideBarStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/SideBarStyle.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:CustomControls="clr-namespace:StudentToolkit.WpfCore.CustomControls.Controls">
+                    xmlns:CustomControls="clr-namespace:StudentToolkit.WpfCore.CustomControls">
 
     <Style x:Key="SideBarStyle" TargetType="{x:Type CustomControls:SideBar}">
         <Setter Property="Background" Value="{DynamicResource SidebarBackgroundBrush}"/>

--- a/src/StudentToolkit/WpfCore/CustomControls/SideBar.cs
+++ b/src/StudentToolkit/WpfCore/CustomControls/SideBar.cs
@@ -2,7 +2,7 @@
 using System.Windows.Controls;
 using System.Windows.Markup;
 
-namespace StudentToolkit.WpfCore.CustomControls.Controls;
+namespace StudentToolkit.WpfCore.CustomControls;
 
 [ContentProperty("Items")]
 public class SideBar : Control


### PR DESCRIPTION
Remove the 'Controls' from namespace of SideBar, because it folder doesn't exists.