### PR TITLE
Refactoring/STL-66 Fix PlaceholderTextBox style

### DIFF
--- a/src/StudentToolkit/Resources/Design/Styles/PlaceholderTextBoxStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/PlaceholderTextBoxStyle.xaml
@@ -8,7 +8,6 @@
         <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrushBrush}"/>
         <Setter Property="BorderThickness" Value="2"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
 
         <Setter Property="Template">
             <Setter.Value>
@@ -56,7 +55,6 @@
 
                             <ScrollViewer
                                 x:Name="PART_ContentHost"
-                                VerticalAlignment="Top"
                                 VerticalScrollBarVisibility="Disabled"
                                 HorizontalScrollBarVisibility="Disabled"/>
                         </Border>


### PR DESCRIPTION
Deleted `VerticalContentAligment` property setter of `PlaceholderTextBox` in style and `ScrollViewer.VerticalAligment` property.