### PR TITLE
Features/STL-54 Add view to showing actual group data.

### DIFF
--- a/src/StudentToolkit/App.xaml.cs
+++ b/src/StudentToolkit/App.xaml.cs
@@ -52,6 +52,8 @@ public partial class App : DotNetApplication
         MainWindow = _options.Services.GetInstance<MainWindow>();
         MainWindow.Show();
 
+        NavigationService.Navigate<MainViewModel, GroupHomePageViewModel>();
+
         return true;
     }
 }

--- a/src/StudentToolkit/Configuration/DI/Extensions/RegisterViewModelsExtension.cs
+++ b/src/StudentToolkit/Configuration/DI/Extensions/RegisterViewModelsExtension.cs
@@ -7,6 +7,7 @@ public static class RegisterViewModelsExtension
         container.RegisterSingleton<MainViewModel>();
         container.RegisterSingleton<AddStudentsToGroupViewModel>();
         container.RegisterSingleton<InputGroupDataViewModel>();
+        container.RegisterSingleton<GroupHomePageViewModel>();
         container.Register<AboutViewModel>();
         container.Register<GroupNotFoundViewModel>();
 

--- a/src/StudentToolkit/Configuration/DI/Extensions/RegisterViewModelsExtension.cs
+++ b/src/StudentToolkit/Configuration/DI/Extensions/RegisterViewModelsExtension.cs
@@ -9,7 +9,6 @@ public static class RegisterViewModelsExtension
         container.RegisterSingleton<InputGroupDataViewModel>();
         container.RegisterSingleton<GroupHomePageViewModel>();
         container.Register<AboutViewModel>();
-        container.Register<GroupNotFoundViewModel>();
 
         return container;
     }

--- a/src/StudentToolkit/MVVM/ViewModels/MainViewModel.cs
+++ b/src/StudentToolkit/MVVM/ViewModels/MainViewModel.cs
@@ -6,13 +6,11 @@ public class MainViewModel : ViewModel
 
     public MainViewModel(IGroupStore groupStore)
     {
-        _contentViewModel = new GroupNotFoundViewModel();
-
         StatusbarViewModel = new StatusbarViewModel();
         WindowTitle = "Student Toolkit";
 
         LoadedEventCommand = new AsyncMainViewLoadedCommand(groupStore);
-        NavigateToGroupInfoViewCommand = new NavigationCommand<MainViewModel, GroupNotFoundViewModel>();
+        NavigateToGroupInfoViewCommand = new NavigationCommand<MainViewModel, GroupHomePageViewModel>();
         NavigateToAboutViewCommand = new NavigationCommand<MainViewModel, AboutViewModel>();
 
         groupStore.GroupStoreChanged += OnStoreChanged;

--- a/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Create/AddStudentsToGroupViewModel.cs
+++ b/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Create/AddStudentsToGroupViewModel.cs
@@ -11,7 +11,7 @@ public class AddStudentsToGroupViewModel : ViewModel
         AsyncCreateGroupCommand = new AsyncCreateGroupCommand(this, groupStore);
         AddStudentCommand = new AddStudentCommand(this);
         GoBackCommand = new NavigationCommand<MainViewModel, InputGroupDataViewModel>();
-        CancelCommand = new NavigationCommand<MainViewModel, GroupNotFoundViewModel>();
+        CancelCommand = new NavigationCommand<MainViewModel, GroupHomePageViewModel>();
     }
 
     public ObservableCollection<StudentViewModel> Students { get; }

--- a/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Create/InputGroupDataViewModel.cs
+++ b/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Create/InputGroupDataViewModel.cs
@@ -14,7 +14,7 @@ public class InputGroupDataViewModel : ViewModel
         ViewTitle = "Укажите данные по Вашей группе";
 
         SetGroupDataAndMoveToNextViewCommand = new SetGroupDataAndMoveToNextViewCommand(this, groupStore.Group);
-        CancelCommand = new NavigationCommand<MainViewModel, GroupNotFoundViewModel>();
+        CancelCommand = new NavigationCommand<MainViewModel, GroupHomePageViewModel>();
     }
 
     public ObservableCollection<string> EducationFormats { get; }

--- a/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Info/GroupHomePageViewModel.cs
+++ b/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Info/GroupHomePageViewModel.cs
@@ -1,0 +1,28 @@
+﻿namespace StudentToolkit.MVVM.ViewModels.Presentation.Group.Info;
+
+public class GroupHomePageViewModel : ViewModel
+{
+    private ViewModel _currentViewModel;
+
+    public GroupHomePageViewModel(IGroupStore groupStore)
+    {
+        ArgumentNullException.ThrowIfNull(groupStore, nameof(groupStore));
+
+        _currentViewModel = new GroupNotFoundViewModel();
+
+        groupStore.GroupStoreChanged += OnGroupStoreChanged;
+    }
+
+    public ViewModel CurrentViewModel
+    {
+        get => _currentViewModel;
+        set => Set(ref _currentViewModel, value);
+    }
+
+    private void OnGroupStoreChanged(GroupViewModel groupVm)
+    {
+        CurrentViewModel = groupVm.Id == Guid.Empty
+            ? new GroupNotFoundViewModel()
+            : new GroupInfoViewModel(groupVm);
+    }
+}

--- a/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Info/GroupInfoViewModel.cs
+++ b/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Info/GroupInfoViewModel.cs
@@ -1,0 +1,13 @@
+﻿namespace StudentToolkit.MVVM.ViewModels.Presentation.Group.Info;
+
+public class GroupInfoViewModel : ViewModel
+{
+    public GroupInfoViewModel(GroupViewModel group)
+    {
+        ArgumentNullException.ThrowIfNull(group, nameof(group));
+
+        Group = group;
+    }
+
+    public GroupViewModel Group { get; }
+}

--- a/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Info/GroupInfoViewModel.cs
+++ b/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Info/GroupInfoViewModel.cs
@@ -7,7 +7,10 @@ public class GroupInfoViewModel : ViewModel
         ArgumentNullException.ThrowIfNull(group, nameof(group));
 
         Group = group;
+        TitleView = "Данные по Вашей группе";
     }
 
     public GroupViewModel Group { get; }
+
+    public string TitleView { get; } 
 }

--- a/src/StudentToolkit/MVVM/Views/Group/Info/GroupHomePageView.xaml
+++ b/src/StudentToolkit/MVVM/Views/Group/Info/GroupHomePageView.xaml
@@ -1,0 +1,11 @@
+﻿<UserControl x:Class="StudentToolkit.MVVM.Views.Group.Info.GroupHomePageView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ViewModel="clr-namespace:StudentToolkit.MVVM.ViewModels.Presentation.Group.Info"
+             d:DataContext="{d:DesignInstance Type=ViewModel:GroupHomePageViewModel}"
+             mc:Ignorable="d">
+
+    <ContentControl Content="{Binding CurrentViewModel}"/>
+</UserControl>

--- a/src/StudentToolkit/MVVM/Views/Group/Info/GroupHomePageView.xaml.cs
+++ b/src/StudentToolkit/MVVM/Views/Group/Info/GroupHomePageView.xaml.cs
@@ -1,0 +1,11 @@
+﻿using System.Windows.Controls;
+
+namespace StudentToolkit.MVVM.Views.Group.Info;
+
+public partial class GroupHomePageView : UserControl
+{
+    public GroupHomePageView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/StudentToolkit/MVVM/Views/Group/Info/GroupInfoView.xaml
+++ b/src/StudentToolkit/MVVM/Views/Group/Info/GroupInfoView.xaml
@@ -1,0 +1,126 @@
+﻿<UserControl x:Class="StudentToolkit.MVVM.Views.Group.Info.GroupInfoView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ViewModel="clr-namespace:StudentToolkit.MVVM.ViewModels.Presentation.Group.Info"
+             d:DataContext="{d:DesignInstance Type=ViewModel:GroupInfoViewModel}"
+             mc:Ignorable="d">
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="10"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock
+            Grid.Row="0"
+            Grid.ColumnSpan="3"
+            FontSize="24"
+            Margin="0 0 0 10"
+            HorizontalAlignment="Center"
+            Text="{Binding TitleView}"/>
+
+        <Border
+            Grid.Column="0"
+            Grid.Row="1"
+            Background="{DynamicResource ContentTileBackgroundBrush}"
+            CornerRadius="25">
+
+            <Grid Grid.Column="0" Margin="30 15">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <TextBlock
+                     Grid.Row="0"
+                     Text="Студенты группы"
+                     HorizontalAlignment="Center"
+                     Margin="0 0 0 10"/>
+
+                <ListView
+                     Grid.Row="1"
+                     SelectionMode="Single"
+                     ItemsSource="{Binding Group.Students}">
+
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="{x:Type ListViewItem}">
+                            <Setter Property="MinWidth" Value="200"/>
+                        </Style>
+                    </ListView.ItemContainerStyle>
+                </ListView>
+            </Grid>
+        </Border>
+
+        <Border
+            Grid.Column="2"
+            Grid.Row="1"
+            CornerRadius="25"
+            Background="{DynamicResource ContentTileBackgroundBrush}">
+
+            <Grid Margin="30 15">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="5"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Text="Шифр группы:" Margin="0 0 0 10"/>
+                    <TextBlock Grid.Row="1" Text="Направление:" Margin="0 0 0 10"/>
+                    <TextBlock Grid.Row="2" Text="Год поступления:" Margin="0 0 0 10"/>
+                    <TextBlock Grid.Row="3" Text="Формат обучения:" Margin="0 0 0 10"/>
+                    <TextBlock Grid.Row="4" Text="Тип образования:" Margin="0 0 0 10"/>
+
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="2"
+                        Text="{Binding Group.GroupCode}"
+                        Margin="0 0 0 10"/>
+                    
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="2"
+                        Text="{Binding Group.EducationDirection}"
+                        Margin="0 0 0 10"/>
+                    
+                    <TextBlock
+                        Grid.Row="2"
+                        Grid.Column="2"
+                        Text="{Binding Group.AdmissionYear}"
+                        Margin="0 0 0 10"/>
+                    
+                    <TextBlock
+                        Grid.Row="3"
+                        Grid.Column="2"
+                        Text="{Binding Group.EducationFormat}"
+                        Margin="0 0 0 10"/>
+                    
+                    <TextBlock
+                        Grid.Row="4"
+                        Grid.Column="2"
+                        Text="{Binding Group.EducationType}"
+                        Margin="0 0 0 10"/>
+                </Grid>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/StudentToolkit/MVVM/Views/Group/Info/GroupInfoView.xaml.cs
+++ b/src/StudentToolkit/MVVM/Views/Group/Info/GroupInfoView.xaml.cs
@@ -1,0 +1,11 @@
+﻿using System.Windows.Controls;
+
+namespace StudentToolkit.MVVM.Views.Group.Info;
+
+public partial class GroupInfoView : UserControl
+{
+    public GroupInfoView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/StudentToolkit/Resources/Design/Themes/DarkBlueTheme.xaml
+++ b/src/StudentToolkit/Resources/Design/Themes/DarkBlueTheme.xaml
@@ -17,6 +17,7 @@
     <Color x:Key="ControlIsFocusedColor">#4266A9</Color>
     <Color x:Key="TextBoxBackgroundColor">#363752</Color>
     <Color x:Key="TextBoxBorderBrushColor">#514F6D</Color>
+    <Color x:Key="ContentTileBackgroundColor">#272638</Color>
     <!--#endregion-->
 
     <!--#region Brushes-->
@@ -36,5 +37,6 @@
     <SolidColorBrush x:Key="ControlIsFocusedBrush" Color="{StaticResource ControlIsFocusedColor}"/>
     <SolidColorBrush x:Key="TextBoxBackgroundBrush" Color="{StaticResource TextBoxBackgroundColor}"/>
     <SolidColorBrush x:Key="TextBoxBorderBrushBrush" Color="{StaticResource TextBoxBorderBrushColor}"/>
+    <SolidColorBrush x:Key="ContentTileBackgroundBrush" Color="{StaticResource ContentTileBackgroundColor}"/>
     <!--#endregion-->
 </ResourceDictionary>

--- a/src/StudentToolkit/WpfCore/Commands/Presentation/Group/AsyncCreateGroupCommand.cs
+++ b/src/StudentToolkit/WpfCore/Commands/Presentation/Group/AsyncCreateGroupCommand.cs
@@ -24,7 +24,7 @@ public sealed class AsyncCreateGroupCommand : AsyncCommand
 
         await _groupStore.CreateGroupAsync();
 
-        NavigationService.Navigate<MainViewModel, GroupNotFoundViewModel>();
+        NavigationService.Navigate<MainViewModel, GroupHomePageViewModel>();
     }
 
     public override bool CanExecute()


### PR DESCRIPTION
## Changes
- Added `GroupHomePageViewModel` and `GroupHomePageView` that contains content view model with group data or group not created info
- Added `GroupInfoViewModel` and `GroupInfoView` for showing to user the actual group data
- `GroupNotFoundViewModel` not registered now to DI container
- Added a navigation to `GroupHomePageViewModel` after successfully startup the application as default view
- Added a new color to `Border.Background` property for UI elements with `Border` into `GroupInfoView`