### PR TITLE
Refactoring/STL-73 Add ViewTitle property to 'ViewModel'

### DIFF
--- a/src/StudentToolkit/MVVM/ViewModels/Base/ViewModel.cs
+++ b/src/StudentToolkit/MVVM/ViewModels/Base/ViewModel.cs
@@ -4,9 +4,10 @@ namespace StudentToolkit.MVVM.ViewModels.Base;
 
 public class ViewModel : INotifyPropertyChanged
 {
-    public string WindowTitle { get; set; } = string.Empty;
-
     public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string WindowTitle { get; set; } = string.Empty;
+    public string ViewTitle { get; set; } = string.Empty;
 
     protected void Set<T>(ref T field, T value, [CallerMemberName] string propertyName = "")
     {

--- a/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Create/AddStudentsToGroupViewModel.cs
+++ b/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Create/AddStudentsToGroupViewModel.cs
@@ -16,7 +16,6 @@ public class AddStudentsToGroupViewModel : ViewModel
 
     public ObservableCollection<StudentViewModel> Students { get; }
     public StudentViewModel Student { get; set; }
-    public string ViewTitle { get; }
 
     public ICommand GoBackCommand { get; }
     public ICommand AsyncCreateGroupCommand { get; }

--- a/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Create/InputGroupDataViewModel.cs
+++ b/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Create/InputGroupDataViewModel.cs
@@ -20,7 +20,6 @@ public class InputGroupDataViewModel : ViewModel
     public ObservableCollection<string> EducationFormats { get; }
     public ObservableCollection<string> EducationTypes { get; }
     public GroupViewModel GroupData { get; }
-    public string ViewTitle { get; }
 
     public ICommand SetGroupDataAndMoveToNextViewCommand { get; }
     public ICommand CancelCommand { get; }

--- a/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Info/GroupInfoViewModel.cs
+++ b/src/StudentToolkit/MVVM/ViewModels/Presentation/Group/Info/GroupInfoViewModel.cs
@@ -7,10 +7,9 @@ public class GroupInfoViewModel : ViewModel
         ArgumentNullException.ThrowIfNull(group, nameof(group));
 
         Group = group;
-        TitleView = "Данные по Вашей группе";
+        
+        ViewTitle = "Данные по Вашей группе";
     }
 
     public GroupViewModel Group { get; }
-
-    public string TitleView { get; } 
 }

--- a/src/StudentToolkit/MVVM/Views/Group/Info/GroupInfoView.xaml
+++ b/src/StudentToolkit/MVVM/Views/Group/Info/GroupInfoView.xaml
@@ -24,7 +24,7 @@
             FontSize="24"
             Margin="0 0 0 10"
             HorizontalAlignment="Center"
-            Text="{Binding TitleView}"/>
+            Text="{Binding ViewTitle}"/>
 
         <Border
             Grid.Column="0"


### PR DESCRIPTION
Added a new property `ViewTitle` to `ViewModel` base class. Copy of it property was deleted from all view models, that contains it locally.