### PR TITLE
Refactoring/STL-87 Fix setting of default styles

### DIFF
--- a/src/StudentToolkit/MVVM/Views/Controls/WindowHeader.xaml
+++ b/src/StudentToolkit/MVVM/Views/Controls/WindowHeader.xaml
@@ -44,7 +44,7 @@
                     Converter={StaticResource WindowButtonVisibilityConverter},
                     ConverterParameter=Minimize}">
 
-                <Path Data="M0,0 L10,0"/>
+                <Path Data="M0,0 L10,0" Style="{StaticResource PathStyle}"/>
             </Button>
 
             <Button
@@ -57,14 +57,17 @@
                     Converter={StaticResource WindowButtonVisibilityConverter},
                     ConverterParameter=Maximize}">
                 
-                <Rectangle Width="12" Height="12"/>
+                <Rectangle
+                    Width="12"
+                    Height="12"
+                    Style="{StaticResource RectangleStyle}"/>
             </Button>
 
             <Button
                 Click="CloseWindowBtnClick"
                 Style="{StaticResource CloseWindowButtonStyle}">
 
-                <Path>
+                <Path Style="{StaticResource PathStyle}">
                     <Path.Data>
                         <GeometryGroup>
                             <LineGeometry StartPoint="0 0" EndPoint="10 10"/>

--- a/src/StudentToolkit/MVVM/Views/Controls/WindowHeader.xaml
+++ b/src/StudentToolkit/MVVM/Views/Controls/WindowHeader.xaml
@@ -44,9 +44,7 @@
                     Converter={StaticResource WindowButtonVisibilityConverter},
                     ConverterParameter=Minimize}">
 
-                <Path
-                    Data="M0,0 L10,0"
-                    Style="{StaticResource ShapeStyle}"/>
+                <Path Data="M0,0 L10,0"/>
             </Button>
 
             <Button
@@ -59,17 +57,14 @@
                     Converter={StaticResource WindowButtonVisibilityConverter},
                     ConverterParameter=Maximize}">
                 
-                <Rectangle
-                    Width="12"
-                    Height="12"
-                    Style="{StaticResource ShapeStyle}"/>
+                <Rectangle Width="12" Height="12"/>
             </Button>
 
             <Button
                 Click="CloseWindowBtnClick"
                 Style="{StaticResource CloseWindowButtonStyle}">
 
-                <Path Style="{StaticResource ShapeStyle}">
+                <Path>
                     <Path.Data>
                         <GeometryGroup>
                             <LineGeometry StartPoint="0 0" EndPoint="10 10"/>

--- a/src/StudentToolkit/MVVM/Views/Group/Create/AddStudentsToGroupView.xaml
+++ b/src/StudentToolkit/MVVM/Views/Group/Create/AddStudentsToGroupView.xaml
@@ -65,6 +65,7 @@
 
         <DataGrid
             Grid.Row="3"
+            ColumnWidth="*"
             ItemsSource="{Binding Students}">
 
             <DataGrid.Columns>

--- a/src/StudentToolkit/MVVM/Views/Group/Create/AddStudentsToGroupView.xaml
+++ b/src/StudentToolkit/MVVM/Views/Group/Create/AddStudentsToGroupView.xaml
@@ -34,35 +34,18 @@
             </Grid.RowDefinitions>
 
             <StackPanel Grid.IsSharedSizeScope="True">
-                <CustomControls:InputField
-                    Title="Фамилия"
-                    Margin="0 0 0 5"
-                    Style="{StaticResource InputFieldStyle}">
-
+                <CustomControls:InputField Title="Фамилия" Margin="0 0 0 5">
                     <TextBox
                         MinWidth="250"
-                        Style="{StaticResource TextBoxStyle}"
                         Text="{Binding Student.LastName, UpdateSourceTrigger=PropertyChanged}"/>
                 </CustomControls:InputField>
 
-                <CustomControls:InputField
-                    Title="Имя"
-                    Margin="0 0 0 5"
-                    Style="{StaticResource InputFieldStyle}">
-
-                    <TextBox
-                        Style="{StaticResource TextBoxStyle}"
-                        Text="{Binding Student.FirstName, UpdateSourceTrigger=PropertyChanged}"/>
+                <CustomControls:InputField Title="Имя" Margin="0 0 0 5">
+                    <TextBox Text="{Binding Student.FirstName, UpdateSourceTrigger=PropertyChanged}"/>
                 </CustomControls:InputField>
 
-                <CustomControls:InputField
-                    Title="Отчество"
-                    Margin="0 0 0 5"
-                    Style="{StaticResource InputFieldStyle}">
-
-                    <TextBox
-                        Style="{StaticResource TextBoxStyle}"
-                        Text="{Binding Student.MiddleName, UpdateSourceTrigger=PropertyChanged}"/>
+                <CustomControls:InputField Title="Отчество" Margin="0 0 0 5">
+                    <TextBox Text="{Binding Student.MiddleName, UpdateSourceTrigger=PropertyChanged}"/>
                 </CustomControls:InputField>
             </StackPanel>
 
@@ -71,8 +54,7 @@
                 Content="Добавить студента"
                 Margin="0 10 0 0"
                 HorizontalAlignment="Left"
-                Command="{Binding AddStudentCommand}"
-                Style="{StaticResource ButtonStyle}"/>
+                Command="{Binding AddStudentCommand}"/>
         </Grid>
 
         <TextBlock
@@ -83,8 +65,7 @@
 
         <DataGrid
             Grid.Row="3"
-            ItemsSource="{Binding Students}"
-            Style="{StaticResource DataGridStyle}">
+            ItemsSource="{Binding Students}">
 
             <DataGrid.Columns>
                 <DataGridTextColumn
@@ -118,20 +99,17 @@
             <Button
                 Content="Вернуться"
                 Margin="0 0 25 0"
-                Command="{Binding GoBackCommand}"
-                Style="{StaticResource ButtonStyle}"/>
+                Command="{Binding GoBackCommand}"/>
 
             <Button
                 Content="Создать"
                 Margin="0 0 25 0"
-                Command="{Binding AsyncCreateGroupCommand}"
-                Style="{StaticResource ButtonStyle}"/>
+                Command="{Binding AsyncCreateGroupCommand}"/>
 
             <Button
                 Content="Отмена"
                 Margin="0 0 25 0"
-                Command="{Binding CancelCommand}"
-                Style="{StaticResource ButtonStyle}"/>
+                Command="{Binding CancelCommand}"/>
         </WrapPanel>
     </Grid>
 </UserControl>

--- a/src/StudentToolkit/MVVM/Views/Group/Create/InputGroupDataView.xaml
+++ b/src/StudentToolkit/MVVM/Views/Group/Create/InputGroupDataView.xaml
@@ -26,16 +26,14 @@
             Grid.Row="1"
             Title="Название направления"
             Margin="0 30"
-            Template="{StaticResource VerticalInputFieldTemplate}"
-            Style="{StaticResource InputFieldStyle}">
+            Template="{StaticResource VerticalInputFieldTemplate}">
 
             <CustomControls:PlaceholderTextBox
                 Placeholder="До 150 символов."
                 Height="80"
                 MaxLength="150"
                 TextWrapping="Wrap"
-                Text="{Binding GroupData.EducationDirection}"
-                Style="{StaticResource PlaceholderTextBoxStyle}"/>
+                Text="{Binding GroupData.EducationDirection}"/>
         </CustomControls:InputField>
 
         <StackPanel
@@ -46,8 +44,7 @@
             <CustomControls:InputField
                 Title="Код группы"
                 Margin="0 0 0 10"
-                VerticalContentAlignment="Stretch"
-                Style="{StaticResource InputFieldStyle}">
+                VerticalContentAlignment="Stretch">
 
                 <CustomControls:PlaceholderTextBox
                     Placeholder="До 50 сим."
@@ -55,46 +52,34 @@
                     TextWrapping="Wrap"
                     MinWidth="200"
                     VerticalContentAlignment="Center"
-                    Style="{StaticResource PlaceholderTextBoxStyle}"
                     Text="{Binding GroupData.GroupCode}"/>
             </CustomControls:InputField>
 
             <CustomControls:InputField
                 Title="Год поступления"
                 VerticalContentAlignment="Stretch"
-                HorizontalAlignment="Left"
-                Style="{StaticResource InputFieldStyle}">
+                HorizontalAlignment="Left">
 
                 <TextBox
                     x:Name="GroupCodeInputTb"
                     MaxLength="4"
                     MinWidth="100"
                     VerticalContentAlignment="Center"
-                    Text="{Binding GroupData.AdmissionYear}"
-                    Style="{StaticResource TextBoxStyle}"/>
+                    Text="{Binding GroupData.AdmissionYear}"/>
             </CustomControls:InputField>
 
-            <CustomControls:InputField
-                Title="Тип образования"
-                Margin="0 10"
-                Style="{StaticResource InputFieldStyle}">
-
+            <CustomControls:InputField Title="Тип образования" Margin="0 10">
                 <ComboBox
                     MinWidth="200"
                     ItemsSource="{Binding EducationTypes}"
-                    SelectedItem="{Binding GroupData.EducationType}"
-                    Style="{StaticResource NotEditableComboBoxStyle}"/>
+                    SelectedItem="{Binding GroupData.EducationType}"/>
             </CustomControls:InputField>
 
-            <CustomControls:InputField
-                Title="Формат обучения"
-                Style="{StaticResource InputFieldStyle}">
-
+            <CustomControls:InputField Title="Формат обучения">
                 <ComboBox
                     MinWidth="200"
                     ItemsSource="{Binding EducationFormats}"
-                    SelectedItem="{Binding GroupData.EducationFormat}"
-                    Style="{StaticResource NotEditableComboBoxStyle}"/>
+                    SelectedItem="{Binding GroupData.EducationFormat}"/>
             </CustomControls:InputField>
         </StackPanel>
 
@@ -107,14 +92,12 @@
                 Margin="0 0 25 0"
                 Content="Далее"
                 IsDefault="True"
-                Command="{Binding SetGroupDataAndMoveToNextViewCommand}"
-                Style="{StaticResource ButtonStyle}"/>
+                Command="{Binding SetGroupDataAndMoveToNextViewCommand}"/>
 
             <Button
                 Content="Отмена"
                 IsCancel="True"
-                Command="{Binding CancelCommand}"
-                Style="{StaticResource ButtonStyle}"/>
+                Command="{Binding CancelCommand}"/>
         </WrapPanel>
     </Grid>
 </UserControl>

--- a/src/StudentToolkit/MVVM/Views/Group/Info/GroupInfoView.xaml
+++ b/src/StudentToolkit/MVVM/Views/Group/Info/GroupInfoView.xaml
@@ -29,8 +29,7 @@
 
         <CustomControls:TileContentControl
             Grid.Column="0"
-            Grid.Row="1"
-            Style="{StaticResource TileContentControlStyle}">
+            Grid.Row="1">
 
             <Grid>
                 <Grid.RowDefinitions>
@@ -48,15 +47,13 @@
                     Grid.Row="1"
                     MinWidth="200"
                     SelectionMode="Single"
-                    ItemsSource="{Binding Group.Students}"
-                    Style="{StaticResource ListViewStyle}"/>
+                    ItemsSource="{Binding Group.Students}"/>
             </Grid>
         </CustomControls:TileContentControl>
 
         <CustomControls:TileContentControl
             Grid.Column="2"
-            Grid.Row="1"
-            Style="{StaticResource TileContentControlStyle}">
+            Grid.Row="1">
 
             <Grid>
                 <Grid.RowDefinitions>

--- a/src/StudentToolkit/MVVM/Views/Group/Info/GroupNotFoundView.xaml
+++ b/src/StudentToolkit/MVVM/Views/Group/Info/GroupNotFoundView.xaml
@@ -19,8 +19,7 @@
             <Button
                 HorizontalAlignment="Center"
                 Content="А давайте создадим её..."
-                Command="{Binding NavigateToCreateGroupViewCommand}"
-                Style="{StaticResource ButtonStyle}"/>
+                Command="{Binding NavigateToCreateGroupViewCommand}"/>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/src/StudentToolkit/MVVM/Views/MainView.xaml
+++ b/src/StudentToolkit/MVVM/Views/MainView.xaml
@@ -28,21 +28,16 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <CustomControls:SideBar
-            Grid.RowSpan="2"
-            Style="{StaticResource SideBarStyle}">
-            
+        <CustomControls:SideBar Grid.RowSpan="2">
             <Button
                 Content="Группа"
                 Margin="0 0 0 10"
-                Command="{Binding NavigateToGroupHomePageCommand}"
-                Style="{StaticResource ButtonStyle}"/>
+                Command="{Binding NavigateToGroupHomePageCommand}"/>
             
             <Button
                 Content="О программе"
                 Margin="0 0 0 10"
-                Command="{Binding NavigateToAboutViewCommand}"
-                Style="{StaticResource ButtonStyle}"/>
+                Command="{Binding NavigateToAboutViewCommand}"/>
         </CustomControls:SideBar>
 
         <ContentControl

--- a/src/StudentToolkit/MVVM/Views/Notification/NotificationView.xaml
+++ b/src/StudentToolkit/MVVM/Views/Notification/NotificationView.xaml
@@ -44,7 +44,6 @@
             Content="Ок"
             VerticalAlignment="Bottom"
             HorizontalAlignment="Right"
-            Command="{Binding CloseNotificationCommand}"
-            Style="{StaticResource ButtonStyle}"/>
+            Command="{Binding CloseNotificationCommand}"/>
     </Grid>
 </UserControl>

--- a/src/StudentToolkit/MVVM/Views/Notification/NotificationWithConfirmView.xaml
+++ b/src/StudentToolkit/MVVM/Views/Notification/NotificationWithConfirmView.xaml
@@ -46,15 +46,13 @@
                 IsDefault="True"
                 Content="Да"
                 Margin="0 0 10 0"
-                Command="{Binding ConfirmNotificationCommand}"
-                Style="{StaticResource ButtonStyle}"/>
+                Command="{Binding ConfirmNotificationCommand}"/>
 
             <Button
                 MinWidth="70"
                 IsCancel="True"
                 Content="Нет"
-                Command="{Binding CloseNotificationCommand}"
-                Style="{StaticResource ButtonStyle}"/>
+                Command="{Binding CloseNotificationCommand}"/>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/src/StudentToolkit/Resources/Design/Styles/Button/BaseButtonStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/Button/BaseButtonStyle.xaml
@@ -1,7 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Style x:Key="BaseButtonStyle" TargetType="{x:Type ButtonBase}">
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="Templates/ButtonTemplate.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <Style
+        TargetType="{x:Type ButtonBase}"
+        BasedOn="{StaticResource {x:Type ButtonBase}}">
+        
         <Setter Property="OverridesDefaultStyle" Value="True"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
@@ -11,5 +18,14 @@
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Background" Value="{DynamicResource ButtonBackgroundBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
+        <Setter Property="Template" Value="{StaticResource ButtonTemplate}"/>
+
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource MouseSelectionBorderBrushBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource MouseSelectionForegroundBrush}"/>
+                <Setter Property="Background" Value="{DynamicResource MouseSelectionBackgroundBrush}"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 </ResourceDictionary>

--- a/src/StudentToolkit/Resources/Design/Styles/Button/ButtonStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/Button/ButtonStyle.xaml
@@ -3,23 +3,13 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="BaseButtonStyle.xaml"/>
-        <ResourceDictionary Source="Templates/ButtonTemplate.xaml"/>
     </ResourceDictionary.MergedDictionaries>
 
     <Style
-        x:Key="ButtonStyle"
-        TargetType="{x:Type ButtonBase}"
-        BasedOn="{StaticResource BaseButtonStyle}">
-        
-        <Setter Property="Template" Value="{StaticResource ButtonTemplate}"/>
+        TargetType="{x:Type Button}"
+        BasedOn="{StaticResource {x:Type ButtonBase}}">
 
         <Style.Triggers>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="BorderBrush" Value="{DynamicResource MouseSelectionBorderBrushBrush}"/>
-                <Setter Property="Foreground" Value="{DynamicResource MouseSelectionForegroundBrush}"/>
-                <Setter Property="Background" Value="{DynamicResource MouseSelectionBackgroundBrush}"/>
-            </Trigger>
-
             <Trigger Property="IsEnabled" Value="False">
                 <Setter Property="Background" Value="{DynamicResource DisabledButtonBackgroundBrush}"/>
                 <Setter Property="BorderBrush" Value="Transparent"/>

--- a/src/StudentToolkit/Resources/Design/Styles/Button/CloseWindowButtonStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/Button/CloseWindowButtonStyle.xaml
@@ -7,7 +7,7 @@
     
     <Style
         x:Key="CloseWindowButtonStyle"
-        TargetType="{x:Type Button}"
+        TargetType="{x:Type ButtonBase}"
         BasedOn="{StaticResource WindowHeaderButtonStyle}">
         
         <Style.Triggers>

--- a/src/StudentToolkit/Resources/Design/Styles/Button/ComboBoxToggleButtonStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/Button/ComboBoxToggleButtonStyle.xaml
@@ -2,14 +2,14 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseButtonStyle.xaml"/>
         <ResourceDictionary Source="Templates/ComboBoxToggleButtonTemplate.xaml"/>
-        <ResourceDictionary Source="ButtonStyle.xaml"/>
     </ResourceDictionary.MergedDictionaries>
     
     <Style
         x:Key="ComboBoxToggleButtonStyle"
         TargetType="{x:Type ToggleButton}"
-        BasedOn="{StaticResource ButtonStyle}">
+        BasedOn="{StaticResource {x:Type ButtonBase}}">
         
         <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushBrush}"/>
         <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundBrush}"/>

--- a/src/StudentToolkit/Resources/Design/Styles/Button/Templates/ComboBoxToggleButtonTemplate.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/Button/Templates/ComboBoxToggleButtonTemplate.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <ControlTemplate x:Key="ComboBoxToggleButtonTemplate" TargetType="{x:Type ToggleButton}">
+    <ControlTemplate x:Key="ComboBoxToggleButtonTemplate" TargetType="{x:Type ButtonBase}">
         <Border
             BorderBrush="{TemplateBinding BorderBrush}"
             Background="{TemplateBinding Background}"

--- a/src/StudentToolkit/Resources/Design/Styles/Button/Templates/DataGridRemoveOperationButtonTemplate.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/Button/Templates/DataGridRemoveOperationButtonTemplate.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="/Resources/Design/Styles/Shape/ShapeStyle.xaml"/>
+        <ResourceDictionary Source="/Resources/Design/Styles/Shape/ShapeStylesDictionary.xaml"/>
     </ResourceDictionary.MergedDictionaries>
     
     <ControlTemplate x:Key="DataGridRemoveOperationButtonTemplate" TargetType="{x:Type Button}">
@@ -11,7 +11,7 @@
             <Path
                 Stroke="Red"
                 Margin="{TemplateBinding Padding}"
-                Style="{StaticResource ShapeStyle}">
+                Style="{StaticResource PathStyle}">
                 
                 <Path.Data>
                     <GeometryGroup>

--- a/src/StudentToolkit/Resources/Design/Styles/Button/Templates/WindowHeaderButtonTemplate.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/Button/Templates/WindowHeaderButtonTemplate.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <ControlTemplate x:Key="WindowHeaderButtonTemplate" TargetType="{x:Type Button}">
+    <ControlTemplate x:Key="WindowHeaderButtonTemplate" TargetType="{x:Type ButtonBase}">
         <Border Background="{TemplateBinding Background}">
             <ContentControl
                 Content="{TemplateBinding Content}"

--- a/src/StudentToolkit/Resources/Design/Styles/Button/WindowHeaderButtonStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/Button/WindowHeaderButtonStyle.xaml
@@ -8,8 +8,8 @@
     
     <Style
         x:Key="WindowHeaderButtonStyle"
-        TargetType="{x:Type Button}"
-        BasedOn="{StaticResource BaseButtonStyle}">
+        TargetType="{x:Type ButtonBase}"
+        BasedOn="{StaticResource {x:Type ButtonBase}}">
 
         <Setter Property="Width" Value="45"/>
         <Setter Property="Padding" Value="0"/>

--- a/src/StudentToolkit/Resources/Design/Styles/ComboBox/NotEditableComboBoxStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/ComboBox/NotEditableComboBoxStyle.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="ComboBoxItem/ComboBoxItemStyle.xaml"/>
     </ResourceDictionary.MergedDictionaries>
 
-    <Style x:Key="NotEditableComboBoxStyle" TargetType="{x:Type ComboBox}">
+    <Style TargetType="{x:Type ComboBox}">
         <Setter Property="OverridesDefaultStyle" Value="True"/>
         <Setter Property="SnapsToDevicePixels" Value="true"/>
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>

--- a/src/StudentToolkit/Resources/Design/Styles/ComboBox/Templates/ComboBoxTemplate.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/ComboBox/Templates/ComboBoxTemplate.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="/Resources/Design/Styles/Shape/ShapeStyle.xaml"/>
+        <ResourceDictionary Source="/Resources/Design/Styles/Shape/ShapeStylesDictionary.xaml"/>
         <ResourceDictionary Source="/Resources/Design/Styles/Button/ComboBoxToggleButtonStyle.xaml"/>
     </ResourceDictionary.MergedDictionaries>
     
@@ -39,7 +39,7 @@
                 IsHitTestVisible="False"
                 Margin="0 0 10 0"
                 Data="M 0 0 L 6 3 L 0 6"
-                Style="{StaticResource ShapeStyle}">
+                Style="{StaticResource PathStyle}">
 
                 <Path.RenderTransform>
                     <RotateTransform

--- a/src/StudentToolkit/Resources/Design/Styles/ContentControl/TileContentControlStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/ContentControl/TileContentControlStyle.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="Templates/TileContentControlTemplate.xaml"/>
     </ResourceDictionary.MergedDictionaries>
     
-    <Style x:Key="TileContentControlStyle" TargetType="{x:Type CustomControls:TileContentControl}">
+    <Style TargetType="{x:Type CustomControls:TileContentControl}">
         <Setter Property="Background" Value="{DynamicResource TileContentControlBackgroundBrush}"/>
         <Setter Property="Padding" Value="30 15"/>
         <Setter Property="Template" Value="{StaticResource TileContentControlTemplate}"/>

--- a/src/StudentToolkit/Resources/Design/Styles/DataGrid/DataGridStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/DataGrid/DataGridStyle.xaml
@@ -7,7 +7,7 @@
         <ResourceDictionary Source="DataGridCell/DataGridCellStyles.xaml"/>
     </ResourceDictionary.MergedDictionaries>
 
-    <Style x:Key="DataGridStyle" TargetType="{x:Type DataGrid}">
+    <Style TargetType="{x:Type DataGrid}">
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="IsReadOnly" Value="True"/>
         <Setter Property="AutoGenerateColumns" Value="False"/>

--- a/src/StudentToolkit/Resources/Design/Styles/DataGrid/DataGridStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/DataGrid/DataGridStyle.xaml
@@ -20,7 +20,6 @@
         <Setter Property="VerticalGridLinesBrush" Value="Transparent"/>
         <Setter Property="HorizontalGridLinesBrush" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AppBorderBrushBrush}"/>
-        <Setter Property="ColumnWidth" Value="*"/>
         <Setter Property="HeadersVisibility" Value="Column"/>
         <Setter Property="EnableRowVirtualization" Value="True"/>
         <Setter Property="CanUserAddRows" Value="False"/>

--- a/src/StudentToolkit/Resources/Design/Styles/InputField/InputFieldStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/InputField/InputFieldStyle.xaml
@@ -6,10 +6,7 @@
         <ResourceDictionary Source="Templates/InputFieldTemplate.xaml"/>
     </ResourceDictionary.MergedDictionaries>
 
-    <Style
-        x:Key="InputFieldStyle"
-        TargetType="{x:Type CustomControls:InputField}">
-        
+    <Style TargetType="{x:Type CustomControls:InputField}">
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
         <Setter Property="Template" Value="{StaticResource InputFieldTemplate}"/>

--- a/src/StudentToolkit/Resources/Design/Styles/ListView/ListViewStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/ListView/ListViewStyle.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="Templates/ListViewTemplate.xaml"/>
     </ResourceDictionary.MergedDictionaries>
     
-    <Style x:Key="ListViewStyle" TargetType="{x:Type ListView}">
+    <Style TargetType="{x:Type ListView}">
         <Setter Property="OverridesDefaultStyle" Value="True"/>
         <Setter Property="ScrollViewer.CanContentScroll" Value="True"/>
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>

--- a/src/StudentToolkit/Resources/Design/Styles/PlaceholderTextBox/PlaceholderTextBoxStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/PlaceholderTextBox/PlaceholderTextBoxStyle.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="Templates/PlaceholderTextBoxTemplate.xaml"/>
     </ResourceDictionary.MergedDictionaries>
     
-    <Style x:Key="PlaceholderTextBoxStyle" TargetType="{x:Type CustomControls:PlaceholderTextBox}">
+    <Style TargetType="{x:Type CustomControls:PlaceholderTextBox}">
         <Setter Property="Padding" Value="5 0 0 0"/>
         <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrushBrush}"/>

--- a/src/StudentToolkit/Resources/Design/Styles/Shape/Path/PathStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/Shape/Path/PathStyle.xaml
@@ -1,0 +1,12 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="../ShapeStyle.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+    
+    <Style
+        x:Key="PathStyle"
+        TargetType="{x:Type Path}"
+        BasedOn="{StaticResource {x:Type Shape}}"/>
+</ResourceDictionary>

--- a/src/StudentToolkit/Resources/Design/Styles/Shape/Rectangle/RectangleStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/Shape/Rectangle/RectangleStyle.xaml
@@ -1,0 +1,12 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="../ShapeStyle.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <Style
+        x:Key="RectangleStyle"
+        TargetType="{x:Type Rectangle}"
+        BasedOn="{StaticResource {x:Type Shape}}"/>
+</ResourceDictionary>

--- a/src/StudentToolkit/Resources/Design/Styles/Shape/ShapeStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/Shape/ShapeStyle.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Style x:Key="ShapeStyle" TargetType="{x:Type Shape}">
+    <Style TargetType="{x:Type Shape}">
         <Setter Property="Stroke" Value="{DynamicResource AppForegroundBrush}"/>
         <Setter Property="StrokeThickness" Value="2"/>
         <Setter Property="VerticalAlignment" Value="Center"/>

--- a/src/StudentToolkit/Resources/Design/Styles/Shape/ShapeStylesDictionary.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/Shape/ShapeStylesDictionary.xaml
@@ -1,5 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ShapeStyle.xaml"/>
+
+        <ResourceDictionary Source="Path/PathStyle.xaml"/>
+        <ResourceDictionary Source="Rectangle/RectangleStyle.xaml"/>
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/StudentToolkit/Resources/Design/Styles/SideBar/SideBarStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/SideBar/SideBarStyle.xaml
@@ -5,8 +5,8 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="Templates/SideBarTemplate.xaml"/>
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="SideBarStyle" TargetType="{x:Type CustomControls:SideBar}">
+
+    <Style TargetType="{x:Type CustomControls:SideBar}">
         <Setter Property="Background" Value="{DynamicResource SidebarBackgroundBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AppBorderBrushBrush}"/>
         <Setter Property="BorderThickness" Value="0 0 1 0"/>

--- a/src/StudentToolkit/Resources/Design/Styles/SideBar/Templates/SideBarTemplate.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/SideBar/Templates/SideBarTemplate.xaml
@@ -4,7 +4,7 @@
     
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Resources/Design/Styles/Button/ButtonStyle.xaml"/>
-        <ResourceDictionary Source="/Resources/Design/Styles/Shape/ShapeStyle.xaml"/>
+        <ResourceDictionary Source="/Resources/Design/Styles/Shape/ShapeStylesDictionary.xaml"/>
     </ResourceDictionary.MergedDictionaries>
     
     <ControlTemplate x:Key="SideBarTemplate" TargetType="{x:Type CustomControls:SideBar}">
@@ -28,10 +28,9 @@
                     Grid.Column="0"
                     Grid.Row="0"
                     Margin="20"
-                    Padding="7"
-                    Style="{StaticResource ButtonStyle}">
+                    Padding="7">
 
-                    <Path Style="{StaticResource ShapeStyle}">
+                    <Path Style="{StaticResource PathStyle}">
                         <Path.Data>
                             <GeometryGroup>
                                 <LineGeometry StartPoint="0 0" EndPoint="20 0"/>

--- a/src/StudentToolkit/Resources/Design/Styles/TextBox/Templates/TextBoxTemplate.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/TextBox/Templates/TextBoxTemplate.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     
-    <ControlTemplate x:Key="TextBoxTemplate" TargetType="{x:Type TextBoxBase}">
+    <ControlTemplate x:Key="TextBoxTemplate" TargetType="{x:Type TextBox}">
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>

--- a/src/StudentToolkit/Resources/Design/Styles/TextBox/TextBoxStyle.xaml
+++ b/src/StudentToolkit/Resources/Design/Styles/TextBox/TextBoxStyle.xaml
@@ -4,8 +4,8 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="Templates/TextBoxTemplate.xaml"/>
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="TextBoxStyle" TargetType="{x:Type TextBox}">
+
+    <Style TargetType="{x:Type TextBox}">
         <Setter Property="OverridesDefaultStyle" Value="True"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="MinWidth" Value="120"/>


### PR DESCRIPTION
## Changes:
- Unseted all `Control.Style` values and removed key values from styles, which should be set as default to special control
- Fix `DataGrid` style: removed `DataGrid.ColumnWidth` property from style and setted this value to concrete `DataGrid` instance
- Shape stle was splitted to special styles, sush as `Path` and `Rectangle`. All base values was saved into `ShapeStyle.xaml`